### PR TITLE
sops: activation: Ensure secrets directory availablity.

### DIFF
--- a/modules/sops/activation.scm
+++ b/modules/sops/activation.scm
@@ -61,23 +61,23 @@
               (format #t "no host key will be generated...~%"))
 
           (format #t "setting up secrets in '~a'...~%" secrets-directory)
-          (when (file-exists? secrets-directory)
-            (begin
-              ;; Cleanup secrets symlink
-              (when (file-exists? extra-links-directory)
-                (for-each
-                 (lambda (link)
-                   (define link-path (string-append extra-links-directory "/" link))
-                   (define link-target (readlink link-path))
-                   ;; The user may have manually deleted the target.
-                   (when (file-exists? link-target)
-                     (format #t "Deleting ~a -> ~a...~%" link-path link-target)
-                     (delete-file-recursively link-target)))
-                 (list-content extra-links-directory)))
-              ;; Cleanup secrets
-              (for-each (compose delete-file-recursively
-                                 (cut string-append secrets-directory "/" <>))
-                        (list-content secrets-directory))))
+          (unless (file-exists? secrets-directory)
+            (mkdir-p secrets-directory))
+          ;; Cleanup secrets symlink
+          (when (file-exists? extra-links-directory)
+            (for-each
+             (lambda (link)
+               (define link-path (string-append extra-links-directory "/" link))
+               (define link-target (readlink link-path))
+               ;; The user may have manually deleted the target.
+               (when (file-exists? link-target)
+                 (format #t "Deleting ~a -> ~a...~%" link-path link-target)
+                 (delete-file-recursively link-target)))
+             (list-content extra-links-directory)))
+          ;; Cleanup secrets
+          (for-each (compose delete-file-recursively
+                             (cut string-append secrets-directory "/" <>))
+                    (list-content secrets-directory))
 
           (chdir secrets-directory)
           (symlink #$config-file (string-append secrets-directory "/.sops.yaml"))

--- a/modules/sops/home/services/sops.scm
+++ b/modules/sops/home/services/sops.scm
@@ -102,12 +102,6 @@ when decrypting a secret.")
                 (extensions (list (service-extension home-profile-service-type
                                                      (lambda (config)
                                                        (list (home-sops-service-configuration-sops config))))
-                                  (service-extension home-activation-service-type
-                                                     (lambda _
-                                                       #~(begin
-                                                           (define secrets-directory (string-append "/run/user/" (number->string (getuid)) "/secrets"))
-                                                           (unless (file-exists? secrets-directory)
-                                                             (mkdir-p secrets-directory)))))
                                   (service-extension home-shepherd-service-type
                                                      home-sops-secrets-shepherd-service)))
                 (compose concatenate)

--- a/modules/sops/services/sops.scm
+++ b/modules/sops/services/sops.scm
@@ -158,13 +158,6 @@ when decrypting a secret.")
                                                        (list (sops-service-configuration-sops config))))
                                   (service-extension file-system-service-type
                                                      %sops-secrets-file-system)
-                                  (service-extension activation-service-type
-                                                     (lambda (config)
-                                                       #~(begin
-                                                           (define secrets-directory
-                                                             #$(sops-service-configuration-secrets-directory config))
-                                                           (unless (file-exists? secrets-directory)
-                                                                   (mkdir-p secrets-directory)))))
                                   (service-extension shepherd-root-service-type
                                                      sops-secrets-shepherd-service)))
                 (compose concatenate)


### PR DESCRIPTION
In my system there're cases that `$XDG_RUNTIME_DIR/secrets` is missing.  This patch fixes the issue.

* modules/sops/activation.scm (activate-secrets): Ensure secrets-directory availablity.
* modules/sops/home/services/sops.scm (home-sops-secrets-service-type) [extensions]: Remove extension of home-activation-service-type.
* modules/sops/services/sops.scm (sops-secrets-service-type)[extensions]: Remove extension of activation-service-type.